### PR TITLE
Inject org.apache.sling.xss.XSSAPI instead of com.adobe.granite.xss.XSSAPI

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,10 +24,10 @@
   <body>
 
     <release version="2.0.0" date="not released">
-      <action type="add" dev="sseifert"><![CDATA[
+      <action type="add" dev="sseifert" issue="3"><![CDATA[
         Add support to inject <code>org.apache.sling.xss.XSSAPI</code>.
       ]]></action>
-      <action type="remove" dev="sseifert"><![CDATA[
+      <action type="remove" dev="sseifert" issue="3"><![CDATA[
         Remove support to inject <code>com.adobe.granite.xss.XSSAPI</code> (deprecated by Adobe).
       ]]></action>
       <action type="update" dev="sseifert">

--- a/changes.xml
+++ b/changes.xml
@@ -23,7 +23,13 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
-    <release version="1.7.0" date="not released">
+    <release version="2.0.0" date="not released">
+      <action type="add" dev="sseifert"><![CDATA[
+        Add support to inject <code>org.apache.sling.xss.XSSAPI</code>.
+      ]]></action>
+      <action type="remove" dev="sseifert"><![CDATA[
+        Remove support to inject <code>com.adobe.granite.xss.XSSAPI</code> (deprecated by Adobe).
+      ]]></action>
       <action type="update" dev="sseifert">
         Switch to Java 11 as minimum version.
       </action>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
   <groupId>io.wcm</groupId>
   <artifactId>io.wcm.sling.models</artifactId>
-  <version>1.6.1-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>AEM Sling Models Extensions</name>

--- a/src/main/java/io/wcm/sling/models/annotations/AemObject.java
+++ b/src/main/java/io/wcm/sling/models/annotations/AemObject.java
@@ -30,9 +30,9 @@ import java.lang.annotation.Target;
 import org.apache.sling.models.annotations.Source;
 import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.spi.injectorspecific.InjectAnnotation;
+import org.apache.sling.xss.XSSAPI;
 
 import com.adobe.granite.workflow.WorkflowSession;
-import com.adobe.granite.xss.XSSAPI;
 import com.day.cq.i18n.I18n;
 import com.day.cq.tagging.TagManager;
 import com.day.cq.wcm.api.AuthoringUIMode;
@@ -186,7 +186,7 @@ import io.wcm.sling.models.injectors.impl.AemObjectInjector;
 @Retention(RUNTIME)
 @InjectAnnotation
 @Source(AemObjectInjector.NAME)
-@SuppressWarnings({ "deprecation", "javadoc" })
+@SuppressWarnings("javadoc")
 public @interface AemObject {
 
   /**

--- a/src/main/java/io/wcm/sling/models/injectors/impl/AemObjectInjector.java
+++ b/src/main/java/io/wcm/sling/models/injectors/impl/AemObjectInjector.java
@@ -35,6 +35,7 @@ import org.apache.sling.models.spi.Injector;
 import org.apache.sling.models.spi.injectorspecific.AbstractInjectAnnotationProcessor2;
 import org.apache.sling.models.spi.injectorspecific.InjectAnnotationProcessor2;
 import org.apache.sling.models.spi.injectorspecific.StaticInjectAnnotationProcessorFactory;
+import org.apache.sling.xss.XSSAPI;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.framework.Constants;
@@ -43,7 +44,6 @@ import org.osgi.service.component.annotations.Reference;
 
 import com.adobe.cq.sightly.WCMBindings;
 import com.adobe.granite.workflow.WorkflowSession;
-import com.adobe.granite.xss.XSSAPI;
 import com.day.cq.i18n.I18n;
 import com.day.cq.tagging.TagManager;
 import com.day.cq.wcm.api.AuthoringUIMode;
@@ -72,7 +72,6 @@ import io.wcm.sling.models.annotations.AemObject;
      */
     Constants.SERVICE_RANKING + ":Integer=" + 4400
 })
-@SuppressWarnings("deprecation")
 public final class AemObjectInjector implements Injector, StaticInjectAnnotationProcessorFactory, AcceptsNullName {
 
   /**
@@ -265,6 +264,7 @@ public final class AemObjectInjector implements Injector, StaticInjectAnnotation
     return null;
   }
 
+  @SuppressWarnings("deprecation")
   private @Nullable Style getStyle(@NotNull final SlingHttpServletRequest request) {
     Style style = null;
     // first try to get from sling bindings
@@ -372,6 +372,7 @@ public final class AemObjectInjector implements Injector, StaticInjectAnnotation
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public Boolean isOptional() {
       return annotation.optional();
     }

--- a/src/test/java/io/wcm/sling/models/injectors/impl/AemObjectInjectorPageTest.java
+++ b/src/test/java/io/wcm/sling/models/injectors/impl/AemObjectInjectorPageTest.java
@@ -31,6 +31,7 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.models.spi.DisposalCallbackRegistry;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.xss.XSSAPI;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,7 +40,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-import com.adobe.granite.xss.XSSAPI;
 import com.day.cq.i18n.I18n;
 import com.day.cq.tagging.TagManager;
 import com.day.cq.wcm.api.AuthoringUIMode;
@@ -58,7 +58,6 @@ import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 @ExtendWith(AemContextExtension.class)
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-@SuppressWarnings("deprecation")
 class AemObjectInjectorPageTest {
 
   private final AemContext context = new AemContext(ResourceResolverType.RESOURCERESOLVER_MOCK);

--- a/src/test/java/io/wcm/sling/models/injectors/impl/AemObjectInjectorRequestTest.java
+++ b/src/test/java/io/wcm/sling/models/injectors/impl/AemObjectInjectorRequestTest.java
@@ -41,6 +41,7 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.scripting.SlingBindings;
 import org.apache.sling.models.spi.DisposalCallbackRegistry;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.xss.XSSAPI;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -51,7 +52,6 @@ import org.mockito.quality.Strictness;
 
 import com.adobe.cq.sightly.WCMBindings;
 import com.adobe.granite.workflow.WorkflowSession;
-import com.adobe.granite.xss.XSSAPI;
 import com.day.cq.i18n.I18n;
 import com.day.cq.tagging.TagManager;
 import com.day.cq.wcm.api.AuthoringUIMode;

--- a/src/test/java/io/wcm/sling/models/injectors/impl/AemObjectInjectorResourceResolverTest.java
+++ b/src/test/java/io/wcm/sling/models/injectors/impl/AemObjectInjectorResourceResolverTest.java
@@ -29,6 +29,7 @@ import java.lang.reflect.AnnotatedElement;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.models.spi.DisposalCallbackRegistry;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.xss.XSSAPI;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,7 +39,6 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import com.adobe.granite.workflow.WorkflowSession;
-import com.adobe.granite.xss.XSSAPI;
 import com.day.cq.i18n.I18n;
 import com.day.cq.tagging.TagManager;
 import com.day.cq.wcm.api.AuthoringUIMode;
@@ -57,7 +57,6 @@ import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 @ExtendWith(AemContextExtension.class)
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-@SuppressWarnings("deprecation")
 class AemObjectInjectorResourceResolverTest {
 
   private final AemContext context = new AemContext(ResourceResolverType.RESOURCERESOLVER_MOCK);

--- a/src/test/java/io/wcm/sling/models/injectors/impl/AemObjectInjectorResourceTest.java
+++ b/src/test/java/io/wcm/sling/models/injectors/impl/AemObjectInjectorResourceTest.java
@@ -31,6 +31,7 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.models.spi.DisposalCallbackRegistry;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.xss.XSSAPI;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,7 +41,6 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import com.adobe.granite.workflow.WorkflowSession;
-import com.adobe.granite.xss.XSSAPI;
 import com.day.cq.i18n.I18n;
 import com.day.cq.tagging.TagManager;
 import com.day.cq.wcm.api.AuthoringUIMode;
@@ -59,7 +59,6 @@ import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 @ExtendWith(AemContextExtension.class)
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-@SuppressWarnings("deprecation")
 class AemObjectInjectorResourceTest {
 
   private final AemContext context = new AemContext(ResourceResolverType.RESOURCERESOLVER_MOCK);


### PR DESCRIPTION
`com.adobe.granite.xss.XSSAPI` is deprecated in recent AEM 6.5 and AEMaaCS versions

this is a breaking change, thus increasing version to 2.0.0